### PR TITLE
feat(header): added link in header to return to github repository

### DIFF
--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -22,8 +22,11 @@ const Header = () => {
                          <a className="pr-3 text-sm border-r-2 md:text-lg border-drip-black/20 hover:text-drip-black/80">How to use</a>
                     </Link>
 
-                    <a target="_blank" rel="noreferrer" className="inline-flex items-center gap-2 text-sm md:text-lg group hover:text-drip-black/80" href="https://twitter.com/intent/tweet?url=https://khazifire.com&text=DripUI%20is%20a%20collection%20of%20free%20Tailwind%20CSS%20components%20that%20can%20be%20used%20in%20your%20next%20project.%20%0A-%20By%20@khazifire%0A"><i className="text-lg ri-twitter-line group-hover:-rotate-12 "></i> Share on twitter</a>
+                    <a target="_blank" rel="noreferrer" className="inline-flex items-center gap-2 pr-3 text-sm md:text-lg group hover:text-drip-black/80 border-r-2 border-drip-black/20" href="https://twitter.com/intent/tweet?url=https://khazifire.com&text=DripUI%20is%20a%20collection%20of%20free%20Tailwind%20CSS%20components%20that%20can%20be%20used%20in%20your%20next%20project.%20%0A-%20By%20@khazifire%0A"><i className="text-lg ri-twitter-line group-hover:-rotate-12 "></i> Share on twitter</a>
                      
+                    <Link href="https://github.com/khazifire/DripUI">
+                        <i className="ri-github-line text-xl hover:cursor-pointer"></i>
+                    </Link>
                   </div>
               </nav>
           </header>


### PR DESCRIPTION
PR has been raised as fix for [issue 9](https://github.com/khazifire/DripUI/issues/9).

Screengrab ( header now has github icon which redirects to the github repo when clicked) : 

<img width="1512" alt="Screenshot 2022-10-02 at 12 34 47 AM" src="https://user-images.githubusercontent.com/31351337/193424514-b4fb1588-4467-4f9e-86a1-028777959792.png">
