### PR TITLE
Fix footer logo text visibility, for ticket (#97)

### DIFF
--- a/components/drip/footer/Footer.js
+++ b/components/drip/footer/Footer.js
@@ -14,8 +14,7 @@ function Footer() {
                     className="p-4 bg-white rounded-lg shadow md:px-6 md:py-8 dark:bg-gray-900">
                     <div className="sm:flex sm:items-center sm:justify-between">
                         <a href="https://dripui.vercel.app/" className="flex items-center mb-4 sm:mb-0">
-                            
-                            <span className="self-center text-2xl font-semibold whitespace-nowrap font-Cursive">DripUI</span>
+                            <span className="self-center text-2xl font-semibold whitespace-nowrap font-Cursive text-gray-500 dark:text-gray-400">DripUI</span>
                         </a>
                         <ul className="flex flex-wrap items-center mb-6 text-sm text-gray-500 sm:mb-0 dark:text-gray-400">
                             <li>


### PR DESCRIPTION
## 🛠️ Fixes Issue

Example: Closes #97 

## 👨‍💻 Changes proposed

This PR:
- Updates the logo text ("DripUI") color from default (black) to match the navigation links' color (text-gray-500 in light mode, dark:text-gray-400 in dark mode).
- This ensures visibility on dark backgrounds and maintains design consistency across the footer.

## ✔️ Check List (Check all the applicable boxes)

- [x] Logo text is visible on dark backgrounds
- [x] Logo text is visible on dark backgrounds
- [x] No impact on other footer elements or layout.


## 📷 Screenshots
After:

<img width="1470" height="830" alt="Screenshot 2026-05-05 at 1 36 06 PM" src="https://github.com/user-attachments/assets/77972bc8-576a-4197-8932-8554bf7b683c" />
